### PR TITLE
Fix generated TS type for "passwordFile" in ServerLoginStartParams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub struct ServerLoginStartParams {
     #[serde(rename = "serverSetup")]
     server_setup: String,
     #[serde(rename = "passwordFile")]
+    #[tsify(type = "string | null | undefined")]
     password_file: Option<String>,
     #[serde(rename = "credentialRequest")]
     credential_request: String,


### PR DESCRIPTION
We need to override the type because the property should be required
but allow null and undefined as value. This is not possible with the
`#tsify(optional)` attribute.