### PR TITLE
Add redis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ wasm-pack.log
 node_modules
 /build/*/**
 !/build/*/package.json
+.env

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ const { sessionKey } = opaque.server.finishLogin({
 
 ## Examples
 
+All server examples require configuration through environment variables to set the `OPAQUE_SERVER_SETUP` variable at a minimum.
+A `.env` file will be automatically generated in the project root when running `pnpm build` if it doesn't exist already.
+You can manually generate it by running `pnpm gen:dotenv`, but by default it will not overwrite an existing file.
+To force overwriting an existing `.env` file you can pass the `--force` flag: `pnpm gen:dotenv --force`.
+
 ### server-simple
 
 A server-side nodejs example with expressjs located in `./examples/server-simple`.
@@ -135,25 +140,25 @@ pnpm example:server:dev
 
 By default the server will use a dummy in-memory database.
 It will load data from `./data.json` and overwrite the file on change.
-You can disable the file persistence by passing the `--no-fs` flag:
+You can disable the file persistence by setting the `DISABLE_FS` env variable in the `.env` file:
 
 ```
-pnpm example:server:dev --no-fs
+DISABLE_FS=true
 ```
 
 #### Redis
 
-The server can alternatively use a redis database which can be enabled by passing the `--redis` flag:
+The server can alternatively use a redis database which can be enabled by setting the `ENABLE_REDIS` variable in the `.env` file:
 
 ```
-pnpm example:server:dev --redis
+ENABLE_REDIS=true
 ```
 
-This will try to to connect to redis on `redis://127.0.0.1:6379`.
-You can optionally pass the redis url if you want to use a different redis host/port:
+By default it will try to connect to redis on `redis://127.0.0.1:6379`.
+You can optionally set the redis url with the `REDIS_URL` variable if you want to use a different redis host/port:
 
 ```
-pnpm example:server:dev --redis redis://192.168.0.1:6379
+REDIS_URL=redis://192.168.0.1:6379
 ```
 
 You can quickly get a redis server running locally using docker, e.g:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,35 @@ You can start the server with
 pnpm example:server:dev
 ```
 
+By default the server will use a dummy in-memory database.
+It will load data from `./data.json` and overwrite the file on change.
+You can disable the file persistence by passing the `--no-fs` flag:
+
+```
+pnpm example:server:dev --no-fs
+```
+
+#### Redis
+
+The server can alternatively use a redis database which can be enabled by passing the `--redis` flag:
+
+```
+pnpm example:server:dev --redis
+```
+
+This will try to to connect to redis on `redis://127.0.0.1:6379`.
+You can optionally pass the redis url if you want to use a different redis host/port:
+
+```
+pnpm example:server:dev --redis redis://192.168.0.1:6379
+```
+
+You can quickly get a redis server running locally using docker, e.g:
+
+```
+ docker run --name redis-opaque -d -p 6379:6379 redis
+```
+
 ### server-with-password-reset
 
 This is the same as the server-simple example but with added password reset endpoints.
@@ -141,6 +170,8 @@ Run with:
 ```
 pnpm example:server-with-password-reset:dev
 ```
+
+This example also supports the `--no-fs` and `--redis` options (see server-simple above).
 
 ### client-simple-webpack
 
@@ -168,6 +199,12 @@ This is the same example app built with nextjs but includes server-side implemen
 ```
 pnpm example:fullstack-simple-nextjs:dev
 ```
+
+#### Redis
+
+This example also supports redis but it needs to be configured through env variables.
+Set `ENABLE_REDIS` to any value to use redis running on localhost and default port `6379`.
+If you want to use another redis host you can set the `REDIS_URL` variable to the redis url.
 
 ### client-with-password-reset
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Run with:
 pnpm example:server-with-password-reset:dev
 ```
 
-This example also supports the `--no-fs` and `--redis` options (see server-simple above).
+This example also supports the `DISABLE_FS`, `ENABLE_REDIS` and `REDIS_URL` env variables (see `server-simple` example above).
 
 ### client-simple-webpack
 
@@ -205,11 +205,7 @@ This is the same example app built with nextjs but includes server-side implemen
 pnpm example:fullstack-simple-nextjs:dev
 ```
 
-#### Redis
-
-This example also supports redis but it needs to be configured through env variables.
-Set `ENABLE_REDIS` to any value to use redis running on localhost and default port `6379`.
-If you want to use another redis host you can set the `REDIS_URL` variable to the redis url.
+This example can also use a redis database through the `ENABLE_REDIS` and `REDIS_URL` env variables (see `server-simple` example above).
 
 ### client-with-password-reset
 

--- a/bin/generate-dotenv.js
+++ b/bin/generate-dotenv.js
@@ -15,7 +15,7 @@ async function main() {
   const baseDir = path.join(__dirname, "..");
   const envFile = path.join(baseDir, ".env");
 
-  if (fileExists(envFile)) {
+  if (fileExists(envFile) && !process.argv.includes("--force")) {
     console.log("opaque .env file already exists, skipping .env write");
     return;
   }
@@ -23,10 +23,15 @@ async function main() {
   await opaque.ready;
   const serverSetup = opaque.server.createSetup();
 
-  const dotEnv = `OPAQUE_SERVER_SETUP=${serverSetup}
+  const dotEnv = `
+# the opaque server setup (private server key)
+OPAQUE_SERVER_SETUP=${serverSetup}
 
-# enable redis for fullstack nextjs example
-# ENABLE_REDIS=1
+# disable filesystem persistence for in-memory db
+# DISABLE_FS=true
+
+# use redis database
+# ENABLE_REDIS=true
 
 # use a custom redis url
 # REDIS_URL=redis://192.168.0.1:6379

--- a/bin/generate-dotenv.js
+++ b/bin/generate-dotenv.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+const opaque = require("../build/ristretto");
+
+function fileExists(file) {
+  try {
+    fs.accessSync(file, fs.constants.F_OK);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+async function main() {
+  const baseDir = path.join(__dirname, "..");
+  const envFile = path.join(baseDir, ".env");
+
+  if (fileExists(envFile)) {
+    console.log("opaque .env file already exists, skipping .env write");
+    return;
+  }
+
+  await opaque.ready;
+  const serverSetup = opaque.server.createSetup();
+
+  const dotEnv = `OPAQUE_SERVER_SETUP=${serverSetup}\n`;
+
+  console.log("writing opaque .env file");
+
+  fs.writeFileSync(envFile, dotEnv);
+}
+
+main();

--- a/bin/generate-dotenv.js
+++ b/bin/generate-dotenv.js
@@ -23,7 +23,14 @@ async function main() {
   await opaque.ready;
   const serverSetup = opaque.server.createSetup();
 
-  const dotEnv = `OPAQUE_SERVER_SETUP=${serverSetup}\n`;
+  const dotEnv = `OPAQUE_SERVER_SETUP=${serverSetup}
+
+# enable redis for fullstack nextjs example
+# ENABLE_REDIS=1
+
+# use a custom redis url
+# REDIS_URL=redis://192.168.0.1:6379
+`;
 
   console.log("writing opaque .env file");
 

--- a/examples/client-simple-vite/main.js
+++ b/examples/client-simple-vite/main.js
@@ -1,6 +1,6 @@
 import * as opaque from "@serenity-kit/opaque";
 
-const host = "http://localhost:8089";
+const host = "/api";
 
 const form = requireFormElement("form");
 const runFullFlowDemoButton = requireElement("run_full_flow_demo");

--- a/examples/client-simple-vite/vite.config.js
+++ b/examples/client-simple-vite/vite.config.js
@@ -1,3 +1,12 @@
 import { defineConfig } from "vite";
 
-export default defineConfig({});
+export default defineConfig({
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8089",
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
+});

--- a/examples/client-simple-webpack/index.js
+++ b/examples/client-simple-webpack/index.js
@@ -1,6 +1,6 @@
 import * as opaque from "@serenity-kit/opaque";
 
-const host = "http://localhost:8089";
+const host = "/api";
 
 const form = requireFormElement("form");
 const runFullFlowDemoButton = requireElement("run_full_flow_demo");

--- a/examples/client-simple-webpack/playwright.config.ts
+++ b/examples/client-simple-webpack/playwright.config.ts
@@ -31,7 +31,10 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: [
     {
-      command: "cd ../../examples/server-simple && pnpm dev --no-fs",
+      env: {
+        DISABLE_FS: "true",
+      },
+      command: "cd ../../examples/server-simple && pnpm dev",
       url: "http://127.0.0.1:8089/private",
       // reuseExistingServer: !process.env.CI,
       reuseExistingServer: false,

--- a/examples/client-simple-webpack/webpack.config.js
+++ b/examples/client-simple-webpack/webpack.config.js
@@ -9,4 +9,12 @@ module.exports = {
   },
   mode: "development",
   plugins: [new CopyWebpackPlugin({ patterns: ["index.html"] })],
+  devServer: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8089",
+        pathRewrite: { "^/api": "" },
+      },
+    },
+  },
 };

--- a/examples/client-with-password-reset/index.js
+++ b/examples/client-with-password-reset/index.js
@@ -1,6 +1,6 @@
 import * as opaque from "@serenity-kit/opaque";
 
-const host = "http://localhost:8089";
+const host = "/api";
 
 const passwordResetConfirm = requireFormElement("password_reset_confirm");
 const passwordResetForm = requireFormElement("password_reset_form");

--- a/examples/client-with-password-reset/webpack.config.js
+++ b/examples/client-with-password-reset/webpack.config.js
@@ -9,4 +9,12 @@ module.exports = {
   },
   mode: "development",
   plugins: [new CopyWebpackPlugin({ patterns: ["index.html"] })],
+  devServer: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8089",
+        pathRewrite: { "^/api": "" },
+      },
+    },
+  },
 };

--- a/examples/fullstack-simple-nextjs/app/api/Datastore.ts
+++ b/examples/fullstack-simple-nextjs/app/api/Datastore.ts
@@ -1,0 +1,9 @@
+export interface Datastore {
+  setUser(name: string, value: string): Promise<void>;
+  getUser(name: string): Promise<string | null>;
+  hasUser(name: string): Promise<boolean>;
+  getLogin(name: string): Promise<string | null>;
+  setLogin(name: string, value: string): Promise<void>;
+  hasLogin(name: string): Promise<boolean>;
+  removeLogin(name: string): Promise<void>;
+}

--- a/examples/fullstack-simple-nextjs/app/api/InMemoryStore.ts
+++ b/examples/fullstack-simple-nextjs/app/api/InMemoryStore.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile } from "fs/promises";
+import { Datastore } from "./Datastore";
+
+type LoginState = { value: string; timestamp: number };
+
+export default class InMemoryStore implements Datastore {
+  constructor(
+    private users: Record<string, string> = {},
+    private logins: Record<string, LoginState> = {},
+    private listeners: (() => Promise<void>)[] = []
+  ) {}
+  addListener(listener: () => Promise<void>) {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index !== -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+  _notifyListeners() {
+    return Promise.all(this.listeners.map((f) => f()));
+  }
+  static empty() {
+    return new InMemoryStore({}, {});
+  }
+  stringify() {
+    return JSON.stringify(
+      {
+        logins: this.logins,
+        users: this.users,
+      },
+      null,
+      2
+    );
+  }
+  async getUser(name: string) {
+    return this.users[name];
+  }
+  async hasUser(name: string) {
+    return this.users[name] != null;
+  }
+  async getLogin(name: string) {
+    const hasLogin = await this.hasLogin(name);
+    return hasLogin ? this.logins[name].value : null;
+  }
+  async hasLogin(name: string) {
+    const login = this.logins[name];
+    if (login == null) return false;
+    const now = new Date().getTime();
+    const elapsed = now - login.timestamp;
+    return elapsed < 2000;
+  }
+  async setUser(name: string, value: string) {
+    this.users[name] = value;
+    await this._notifyListeners();
+  }
+  async setLogin(name: string, value: string) {
+    this.logins[name] = { value, timestamp: new Date().getTime() };
+    await this._notifyListeners();
+  }
+  async removeLogin(name: string) {
+    delete this.logins[name];
+    await this._notifyListeners();
+  }
+}
+
+export async function readDatabaseFile(filePath: string) {
+  const json = await readFile(filePath, "utf-8");
+  const data = JSON.parse(json);
+  const db = new InMemoryStore(data.serverSetup, data.users, data.logins);
+  return db;
+}
+
+export function writeDatabaseFile(filePath: string, db: InMemoryStore) {
+  const data = db.stringify();
+  return writeFile(filePath, data);
+}

--- a/examples/fullstack-simple-nextjs/app/api/InMemoryStore.ts
+++ b/examples/fullstack-simple-nextjs/app/api/InMemoryStore.ts
@@ -68,7 +68,7 @@ export default class InMemoryStore implements Datastore {
 export async function readDatabaseFile(filePath: string) {
   const json = await readFile(filePath, "utf-8");
   const data = JSON.parse(json);
-  const db = new InMemoryStore(data.serverSetup, data.users, data.logins);
+  const db = new InMemoryStore(data.users, data.logins);
   return db;
 }
 

--- a/examples/fullstack-simple-nextjs/app/api/RedisStore.ts
+++ b/examples/fullstack-simple-nextjs/app/api/RedisStore.ts
@@ -1,0 +1,47 @@
+import * as redis from "redis";
+import { Datastore } from "./Datastore";
+
+export default class RedisStore implements Datastore {
+  private readonly client: ReturnType<typeof redis.createClient>;
+  constructor(url: string) {
+    this.client = redis.createClient({ url });
+  }
+
+  onError(handler: (err: unknown) => void) {
+    this.client.on("error", handler);
+  }
+
+  connect() {
+    return this.client.connect();
+  }
+
+  async getUser(name: string) {
+    return this.client.get(`user:${name}`);
+  }
+
+  async hasUser(name: string) {
+    const user = await this.getUser(name);
+    return user != null;
+  }
+
+  getLogin(name: string) {
+    return this.client.get(`login:${name}`);
+  }
+
+  async hasLogin(name: string) {
+    const login = await this.getLogin(name);
+    return login != null;
+  }
+
+  async setUser(name: string, value: string) {
+    await this.client.set(`user:${name}`, value);
+  }
+
+  async setLogin(name: string, value: string) {
+    await this.client.set(`login:${name}`, value, { EX: 2 });
+  }
+
+  async removeLogin(name: string) {
+    await this.client.del(`login:${name}`);
+  }
+}

--- a/examples/fullstack-simple-nextjs/app/api/env.ts
+++ b/examples/fullstack-simple-nextjs/app/api/env.ts
@@ -1,0 +1,17 @@
+export function requireEnv(key: string) {
+  const value = process.env[key];
+  if (value == null) throw new Error(`missing value for env variable "${key}"`);
+  return value;
+}
+
+export function hasEnv(key: string) {
+  return process.env[key] != null;
+}
+
+export function getEnv(key: string, defaultValue: string) {
+  return process.env[key] ?? defaultValue;
+}
+
+export const SERVER_SETUP = requireEnv("OPAQUE_SERVER_SETUP");
+export const ENABLE_REDIS = hasEnv("ENABLE_REDIS");
+export const REDIS_URL = getEnv("REDIS_URL", "redis://127.0.0.1:6379");

--- a/examples/fullstack-simple-nextjs/app/api/env.ts
+++ b/examples/fullstack-simple-nextjs/app/api/env.ts
@@ -1,3 +1,7 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../../.env" });
+
 export function requireEnv(key: string) {
   const value = process.env[key];
   if (value == null) throw new Error(`missing value for env variable "${key}"`);

--- a/examples/fullstack-simple-nextjs/app/api/login/finish/route.ts
+++ b/examples/fullstack-simple-nextjs/app/api/login/finish/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest) {
     );
 
   const db = await database;
-  const serverLoginState = userIdentifier && db.getLogin(userIdentifier);
+  const serverLoginState = await db.getLogin(userIdentifier);
 
   if (!serverLoginState)
     return NextResponse.json({ error: "login not started" }, { status: 400 });

--- a/examples/fullstack-simple-nextjs/app/api/login/start/route.ts
+++ b/examples/fullstack-simple-nextjs/app/api/login/start/route.ts
@@ -1,6 +1,7 @@
 import * as opaque from "@serenity-kit/opaque";
 import { NextRequest, NextResponse } from "next/server";
 import database from "../../db";
+import { SERVER_SETUP } from "../../env";
 
 export async function POST(request: NextRequest) {
   const { userIdentifier, startLoginRequest } = await request.json();
@@ -17,19 +18,20 @@ export async function POST(request: NextRequest) {
     );
 
   const db = await database;
-  const registrationRecord = userIdentifier && db.getUser(userIdentifier);
+  const registrationRecord = await db.getUser(userIdentifier);
 
   if (!registrationRecord)
     return NextResponse.json({ error: "user not registered" }, { status: 400 });
 
-  if (db.hasLogin(userIdentifier))
+  const hasLogin = await db.hasLogin(userIdentifier);
+  if (hasLogin)
     return NextResponse.json(
       { error: "login already started" },
       { status: 400 }
     );
 
   const { serverLoginState, loginResponse } = opaque.server.startLogin({
-    serverSetup: db.getServerSetup(),
+    serverSetup: SERVER_SETUP,
     userIdentifier,
     registrationRecord,
     startLoginRequest,

--- a/examples/fullstack-simple-nextjs/app/api/register/start/route.ts
+++ b/examples/fullstack-simple-nextjs/app/api/register/start/route.ts
@@ -1,6 +1,7 @@
 import * as opaque from "@serenity-kit/opaque";
 import { NextRequest, NextResponse } from "next/server";
 import database from "../../db";
+import { SERVER_SETUP } from "../../env";
 
 export async function POST(req: NextRequest) {
   const { userIdentifier, registrationRequest } = await req.json();
@@ -17,15 +18,15 @@ export async function POST(req: NextRequest) {
     );
 
   const db = await database;
-
-  if (db.hasUser(userIdentifier))
+  const hasUser = await db.hasUser(userIdentifier);
+  if (hasUser)
     return NextResponse.json(
       { error: "user already registered" },
       { status: 400 }
     );
 
   const { registrationResponse } = opaque.server.createRegistrationResponse({
-    serverSetup: db.getServerSetup(),
+    serverSetup: SERVER_SETUP,
     userIdentifier,
     registrationRequest,
   });

--- a/examples/fullstack-simple-nextjs/package.json
+++ b/examples/fullstack-simple-nextjs/package.json
@@ -14,6 +14,7 @@
     "@types/react": "18.2.8",
     "@types/react-dom": "18.2.4",
     "autoprefixer": "10.4.14",
+    "dotenv": "^16.3.1",
     "eslint": "8.42.0",
     "eslint-config-next": "13.4.4",
     "next": "13.4.4",

--- a/examples/fullstack-simple-nextjs/package.json
+++ b/examples/fullstack-simple-nextjs/package.json
@@ -20,6 +20,7 @@
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "redis": "^4.6.7",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.3"
   }

--- a/examples/server-simple/package.json
+++ b/examples/server-simple/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@serenity-kit/opaque": "workspace:*",
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "redis": "^4.6.7"
   },

--- a/examples/server-simple/package.json
+++ b/examples/server-simple/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "@serenity-kit/opaque": "workspace:*",
-    "cors": "^2.8.5",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "redis": "^4.6.7"
@@ -11,7 +11,7 @@
     "dev": "node ./src/server.js"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.13",
+    "@types/cookie-parser": "^1.4.3",
     "@types/express": "^4.17.17"
   }
 }

--- a/examples/server-simple/package.json
+++ b/examples/server-simple/package.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "@serenity-kit/opaque": "workspace:*",
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "redis": "^4.6.7"
   },
   "scripts": {
     "dev": "node ./src/server.js"

--- a/examples/server-simple/src/InMemoryStore.js
+++ b/examples/server-simple/src/InMemoryStore.js
@@ -15,6 +15,8 @@ export default class InMemoryStore {
     this.logins = logins;
     /** @type {(() => void)[]} */
     this.listeners = [];
+    /** @type {Record<string,SessionData>} */
+    this.sessions = {};
   }
 
   /**
@@ -108,6 +110,28 @@ export default class InMemoryStore {
   async removeLogin(name) {
     delete this.logins[name];
     this._notifyListeners();
+  }
+
+  /**
+   * @param {string} id
+   */
+  async getSession(id) {
+    return this.sessions[id];
+  }
+
+  /**
+   * @param {string} id
+   * @param {SessionData} session
+   */
+  async setSession(id, session) {
+    this.sessions[id] = session;
+  }
+
+  /**
+   * @param {string} id
+   */
+  async clearSession(id) {
+    delete this.sessions[id];
   }
 }
 

--- a/examples/server-simple/src/InMemoryStore.js
+++ b/examples/server-simple/src/InMemoryStore.js
@@ -1,7 +1,10 @@
 import { readFileSync } from "fs";
 import { writeFile } from "fs/promises";
 
-export default class Database {
+/**
+ * @implements Datastore
+ */
+export default class InMemoryStore {
   /**
    * @constructor
    * @param {string} serverSetup
@@ -39,7 +42,7 @@ export default class Database {
    * @param {string} serverSetup
    */
   static empty(serverSetup) {
-    return new Database(serverSetup, {}, {});
+    return new InMemoryStore(serverSetup, {}, {});
   }
 
   stringify() {
@@ -57,39 +60,41 @@ export default class Database {
   /**
    * @param {string} name
    */
-  getUser(name) {
+  async getUser(name) {
     return this.users[name];
   }
 
   /**
    * @param {string} name
    */
-  hasUser(name) {
+  async hasUser(name) {
     return this.users[name] != null;
   }
 
   /**
    * @param {string} name
    */
-  getLogin(name) {
-    return this.hasLogin(name) ? this.logins[name].value : null;
+  async getLogin(name) {
+    const hasLogin = await this.hasLogin(name);
+    return hasLogin ? this.logins[name].value : null;
   }
 
   /**
    * @param {string} name
    */
-  hasLogin(name) {
+  async hasLogin(name) {
     const login = this.logins[name];
-    if (login == null) return null;
+    if (login == null) return false;
     const now = new Date().getTime();
     const elapsed = now - login.timestamp;
     return elapsed < 2000;
   }
+
   /**
    * @param {string} name
    * @param {string} value
    */
-  setUser(name, value) {
+  async setUser(name, value) {
     this.users[name] = value;
     this._notifyListeners();
   }
@@ -98,7 +103,7 @@ export default class Database {
    * @param {string} name
    * @param {string} value
    */
-  setLogin(name, value) {
+  async setLogin(name, value) {
     this.logins[name] = { value, timestamp: new Date().getTime() };
     this._notifyListeners();
   }
@@ -106,7 +111,7 @@ export default class Database {
   /**
    * @param {string} name
    */
-  removeLogin(name) {
+  async removeLogin(name) {
     delete this.logins[name];
     this._notifyListeners();
   }
@@ -118,13 +123,13 @@ export default class Database {
 export function readDatabaseFile(filePath) {
   const json = readFileSync(filePath, "utf-8");
   const data = JSON.parse(json);
-  const db = new Database(data.serverSetup, data.users, data.logins);
+  const db = new InMemoryStore(data.serverSetup, data.users, data.logins);
   return db;
 }
 
 /**
  * @param {string} filePath
- * @param {Database} db
+ * @param {InMemoryStore} db
  */
 export function writeDatabaseFile(filePath, db) {
   const data = db.stringify();

--- a/examples/server-simple/src/InMemoryStore.js
+++ b/examples/server-simple/src/InMemoryStore.js
@@ -7,12 +7,10 @@ import { writeFile } from "fs/promises";
 export default class InMemoryStore {
   /**
    * @constructor
-   * @param {string} serverSetup
    * @param {Record<string, string>} users
    * @param {Record<string, {value: string; timestamp: number}>} logins
    */
-  constructor(serverSetup, users, logins) {
-    this.serverSetup = serverSetup;
+  constructor(users, logins) {
     this.users = users;
     this.logins = logins;
     /** @type {(() => void)[]} */
@@ -38,17 +36,13 @@ export default class InMemoryStore {
     }
   }
 
-  /**
-   * @param {string} serverSetup
-   */
-  static empty(serverSetup) {
-    return new InMemoryStore(serverSetup, {}, {});
+  static empty() {
+    return new InMemoryStore({}, {});
   }
 
   stringify() {
     return JSON.stringify(
       {
-        serverSetup: this.serverSetup,
         logins: this.logins,
         users: this.users,
       },
@@ -123,7 +117,7 @@ export default class InMemoryStore {
 export function readDatabaseFile(filePath) {
   const json = readFileSync(filePath, "utf-8");
   const data = JSON.parse(json);
-  const db = new InMemoryStore(data.serverSetup, data.users, data.logins);
+  const db = new InMemoryStore(data.users, data.logins);
   return db;
 }
 

--- a/examples/server-simple/src/RedisStore.js
+++ b/examples/server-simple/src/RedisStore.js
@@ -74,4 +74,30 @@ export default class RedisStore {
   async removeLogin(name) {
     await this.client.del(`login:${name}`);
   }
+
+  /**
+   * @param {string} id
+   */
+  async getSession(id) {
+    const { userIdentifier, sessionKey } = await this.client.hGetAll(
+      `session:${id}`
+    );
+    if (!userIdentifier || !sessionKey) throw new TypeError();
+    return { userIdentifier, sessionKey };
+  }
+
+  /**
+   * @param {string} id
+   * @param {SessionData} session
+   */
+  async setSession(id, session) {
+    await this.client.hSet(`session:${id}`, /** @type {any} */ (session));
+  }
+
+  /**
+   * @param {string} id
+   */
+  async clearSession(id) {
+    await this.client.del(`session:${id}`);
+  }
 }

--- a/examples/server-simple/src/RedisStore.js
+++ b/examples/server-simple/src/RedisStore.js
@@ -22,17 +22,6 @@ export default class RedisStore {
     return this.client.connect();
   }
 
-  getServerSetup() {
-    return this.client.get("serverSetup");
-  }
-
-  /**
-   * @param {string} serverSetup
-   */
-  async setServerSetup(serverSetup) {
-    await this.client.set("serverSetup", serverSetup);
-  }
-
   /**
    * @param {string} name
    */

--- a/examples/server-simple/src/RedisStore.js
+++ b/examples/server-simple/src/RedisStore.js
@@ -1,0 +1,79 @@
+import * as redis from "redis";
+
+/**
+ * @implements Datastore
+ */
+export default class RedisStore {
+  constructor() {
+    this.client = redis.createClient();
+    this.client.on("error", (err) => console.error("Redis Client Error", err));
+  }
+
+  connect() {
+    return this.client.connect();
+  }
+
+  getServerSetup() {
+    return this.client.get("serverSetup");
+  }
+
+  /**
+   * @param {string} serverSetup
+   */
+  async setServerSetup(serverSetup) {
+    await this.client.set("serverSetup", serverSetup);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async getUser(name) {
+    return this.client.get(`user:${name}`);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async hasUser(name) {
+    const user = await this.getUser(name);
+    return user != null;
+  }
+
+  /**
+   * @param {string} name
+   */
+  getLogin(name) {
+    return this.client.get(`login:${name}`);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async hasLogin(name) {
+    const login = await this.getLogin(name);
+    return login != null;
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} value
+   */
+  async setUser(name, value) {
+    await this.client.set(`user:${name}`, value);
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} value
+   */
+  async setLogin(name, value) {
+    await this.client.set(`login:${name}`, value, { EX: 2 });
+  }
+
+  /**
+   * @param {string} name
+   */
+  async removeLogin(name) {
+    await this.client.del(`login:${name}`);
+  }
+}

--- a/examples/server-simple/src/RedisStore.js
+++ b/examples/server-simple/src/RedisStore.js
@@ -4,9 +4,18 @@ import * as redis from "redis";
  * @implements Datastore
  */
 export default class RedisStore {
-  constructor() {
-    this.client = redis.createClient();
-    this.client.on("error", (err) => console.error("Redis Client Error", err));
+  /**
+   * @param {string|undefined} url
+   */
+  constructor(url) {
+    this.client = redis.createClient({ url });
+  }
+
+  /**
+   * @param {(err: unknown) => void} handler
+   */
+  onError(handler) {
+    this.client.on("error", handler);
   }
 
   connect() {

--- a/examples/server-simple/src/RedisStore.js
+++ b/examples/server-simple/src/RedisStore.js
@@ -5,7 +5,7 @@ import * as redis from "redis";
  */
 export default class RedisStore {
   /**
-   * @param {string|undefined} url
+   * @param {string} url
    */
   constructor(url) {
     this.client = redis.createClient({ url });

--- a/examples/server-simple/src/datastore.d.ts
+++ b/examples/server-simple/src/datastore.d.ts
@@ -1,0 +1,9 @@
+interface Datastore {
+  setUser(name: string, value: string): Promise<void>;
+  getUser(name: string): Promise<string | null>;
+  hasUser(name: string): Promise<boolean>;
+  getLogin(name: string): Promise<string | null>;
+  setLogin(name: string, value: string): Promise<void>;
+  hasLogin(name: string): Promise<boolean>;
+  removeLogin(name: string): Promise<void>;
+}

--- a/examples/server-simple/src/datastore.d.ts
+++ b/examples/server-simple/src/datastore.d.ts
@@ -1,3 +1,8 @@
+interface SessionData {
+  userIdentifier: string;
+  sessionKey: string;
+}
+
 interface Datastore {
   setUser(name: string, value: string): Promise<void>;
   getUser(name: string): Promise<string | null>;
@@ -6,4 +11,7 @@ interface Datastore {
   setLogin(name: string, value: string): Promise<void>;
   hasLogin(name: string): Promise<boolean>;
   removeLogin(name: string): Promise<void>;
+  getSession(id: string): Promise<SessionData>;
+  setSession(id: string, session: SessionData);
+  clearSession(id: string): Promise<void>;
 }

--- a/examples/server-simple/src/server.js
+++ b/examples/server-simple/src/server.js
@@ -15,6 +15,8 @@ const dbFile = "./data.json";
 const enableJsonFilePersistence = !process.argv.includes("--no-fs");
 const enableRedis = process.argv.includes("--redis");
 
+const DEFAULT_REDIS_URL = "redis://127.0.0.1:6379";
+
 /**
  * @param {string} filePath
  */
@@ -57,17 +59,18 @@ async function setUpInMemoryStore() {
 
 function getRedisUrl() {
   const optIndex = process.argv.indexOf("--redis");
-  if (optIndex == -1) return undefined;
+  if (optIndex == -1) return DEFAULT_REDIS_URL;
   const valIndex = optIndex + 1;
   if (valIndex < process.argv.length) {
     return process.argv[valIndex];
   }
-  return undefined;
+  return DEFAULT_REDIS_URL;
 }
 
 async function setUpRedisStore() {
   try {
-    const redis = new RedisStore(getRedisUrl());
+    const redisUrl = getRedisUrl();
+    const redis = new RedisStore(redisUrl);
     redis.onError((err) => {
       console.error("Redis Error:", err instanceof Error ? err.message : err);
       process.exit(1);
@@ -80,6 +83,7 @@ async function setUpRedisStore() {
     }
     serverSetup = _serverSetup;
     db = redis;
+    console.log("connected to redis at", redisUrl);
   } catch (err) {
     console.error(
       "Redis Setup Error:",

--- a/examples/server-simple/src/server.js
+++ b/examples/server-simple/src/server.js
@@ -7,7 +7,6 @@ import InMemoryStore, {
 } from "./InMemoryStore.js";
 import RedisStore from "./RedisStore.js";
 import * as dotenv from "dotenv";
-import * as path from "path";
 
 /**
  * @type {Record<string, string>}

--- a/examples/server-with-password-reset/package.json
+++ b/examples/server-with-password-reset/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@serenity-kit/opaque": "workspace:*",
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "redis": "^4.6.7"
   },

--- a/examples/server-with-password-reset/package.json
+++ b/examples/server-with-password-reset/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "@serenity-kit/opaque": "workspace:*",
-    "cors": "^2.8.5",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "redis": "^4.6.7"
@@ -11,7 +11,7 @@
     "dev": "node ./src/server.js"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.13",
+    "@types/cookie-parser": "^1.4.3",
     "@types/express": "^4.17.17"
   }
 }

--- a/examples/server-with-password-reset/package.json
+++ b/examples/server-with-password-reset/package.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "@serenity-kit/opaque": "workspace:*",
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "redis": "^4.6.7"
   },
   "scripts": {
     "dev": "node ./src/server.js"

--- a/examples/server-with-password-reset/src/Datastore.d.ts
+++ b/examples/server-with-password-reset/src/Datastore.d.ts
@@ -1,0 +1,13 @@
+interface DatastoreWithPasswordReset {
+  setUser(name: string, value: string): Promise<void>;
+  getUser(name: string): Promise<string | null>;
+  hasUser(name: string): Promise<boolean>;
+  getLogin(name: string): Promise<string | null>;
+  setLogin(name: string, value: string): Promise<void>;
+  hasLogin(name: string): Promise<boolean>;
+  removeLogin(name: string): Promise<void>;
+  hasResetCode(name: string): Promise<boolean>;
+  getResetCode(name: string): Promise<string | null>;
+  setResetCode(name: string, code: string): Promise<void>;
+  removeResetCode(name: string): Promise<void>;
+}

--- a/examples/server-with-password-reset/src/Datastore.d.ts
+++ b/examples/server-with-password-reset/src/Datastore.d.ts
@@ -10,4 +10,7 @@ interface DatastoreWithPasswordReset {
   getResetCode(name: string): Promise<string | null>;
   setResetCode(name: string, code: string): Promise<void>;
   removeResetCode(name: string): Promise<void>;
+  getSession(id: string): Promise<SessionData>;
+  setSession(id: string, session: SessionData);
+  clearSession(id: string): Promise<void>;
 }

--- a/examples/server-with-password-reset/src/InMemoryStore.js
+++ b/examples/server-with-password-reset/src/InMemoryStore.js
@@ -57,6 +57,8 @@ export default class InMemoryStore {
     this.resetCodes = {};
     /** @type {(() => void)[]} */
     this.listeners = [];
+    /** @type {Record<string,SessionData>} */
+    this.sessions = {};
   }
 
   /**
@@ -209,6 +211,28 @@ export default class InMemoryStore {
       await this.removeResetCode(user);
     }
     return null;
+  }
+
+  /**
+   * @param {string} id
+   */
+  async getSession(id) {
+    return this.sessions[id];
+  }
+
+  /**
+   * @param {string} id
+   * @param {SessionData} session
+   */
+  async setSession(id, session) {
+    this.sessions[id] = session;
+  }
+
+  /**
+   * @param {string} id
+   */
+  async clearSession(id) {
+    delete this.sessions[id];
   }
 }
 

--- a/examples/server-with-password-reset/src/InMemoryStore.js
+++ b/examples/server-with-password-reset/src/InMemoryStore.js
@@ -41,10 +41,8 @@ function pruneResetCodes(codes) {
 export default class InMemoryStore {
   /**
    * @constructor
-   * @param {string} serverSetup
    */
-  constructor(serverSetup) {
-    this.serverSetup = serverSetup;
+  constructor() {
     /**
      * @type {Record<string,string>}
      */
@@ -69,11 +67,11 @@ export default class InMemoryStore {
    * resetCodes?: Record<string, ResetCode>
    * }} params
    */
-  static init({ serverSetup, ...data }) {
-    const db = new InMemoryStore(serverSetup);
-    db.users = data.users || {};
-    db.logins = data.logins || {};
-    db.resetCodes = data.resetCodes || {};
+  static init(params) {
+    const db = new InMemoryStore();
+    db.users = params.users || {};
+    db.logins = params.logins || {};
+    db.resetCodes = params.resetCodes || {};
     return db;
   }
 
@@ -97,17 +95,13 @@ export default class InMemoryStore {
     }
   }
 
-  /**
-   * @param {string} serverSetup
-   */
-  static empty(serverSetup) {
-    return new InMemoryStore(serverSetup);
+  static empty() {
+    return new InMemoryStore();
   }
 
   stringify() {
     return JSON.stringify(
       {
-        serverSetup: this.serverSetup,
         logins: this.logins,
         users: this.users,
         resetCodes: pruneResetCodes(this.resetCodes),

--- a/examples/server-with-password-reset/src/RedisStore.js
+++ b/examples/server-with-password-reset/src/RedisStore.js
@@ -24,17 +24,6 @@ export default class RedisStore {
     return this.client.connect();
   }
 
-  getServerSetup() {
-    return this.client.get("serverSetup");
-  }
-
-  /**
-   * @param {string} serverSetup
-   */
-  async setServerSetup(serverSetup) {
-    await this.client.set("serverSetup", serverSetup);
-  }
-
   /**
    * @param {string} name
    */

--- a/examples/server-with-password-reset/src/RedisStore.js
+++ b/examples/server-with-password-reset/src/RedisStore.js
@@ -1,0 +1,120 @@
+import * as redis from "redis";
+
+const RESET_CODE_VALIDITY = 600; // 10 minutes in seconds
+
+/**
+ * @implements DatastoreWithPasswordReset
+ */
+export default class RedisStore {
+  /**
+   * @param {string} url
+   */
+  constructor(url) {
+    this.client = redis.createClient({ url });
+  }
+
+  /**
+   * @param {(err: unknown) => void} handler
+   */
+  onError(handler) {
+    this.client.on("error", handler);
+  }
+
+  connect() {
+    return this.client.connect();
+  }
+
+  getServerSetup() {
+    return this.client.get("serverSetup");
+  }
+
+  /**
+   * @param {string} serverSetup
+   */
+  async setServerSetup(serverSetup) {
+    await this.client.set("serverSetup", serverSetup);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async getUser(name) {
+    return this.client.get(`user:${name}`);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async hasUser(name) {
+    const user = await this.getUser(name);
+    return user != null;
+  }
+
+  /**
+   * @param {string} name
+   */
+  getLogin(name) {
+    return this.client.get(`login:${name}`);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async hasLogin(name) {
+    const login = await this.getLogin(name);
+    return login != null;
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} value
+   */
+  async setUser(name, value) {
+    await this.client.set(`user:${name}`, value);
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} value
+   */
+  async setLogin(name, value) {
+    await this.client.set(`login:${name}`, value, { EX: 2 });
+  }
+
+  /**
+   * @param {string} name
+   */
+  async removeLogin(name) {
+    await this.client.del(`login:${name}`);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async getResetCode(name) {
+    return this.client.get(`reset:${name}`);
+  }
+
+  /**
+   * @param {string} name
+   */
+  async hasResetCode(name) {
+    const code = await this.getResetCode(name);
+    return code != null;
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} code
+   */
+  async setResetCode(name, code) {
+    await this.client.set(`reset:${name}`, code, { EX: RESET_CODE_VALIDITY });
+  }
+
+  /**
+   * @param {string} name
+   */
+  async removeResetCode(name) {
+    await this.client.del(`reset:${name}`);
+  }
+}

--- a/examples/server-with-password-reset/src/RedisStore.js
+++ b/examples/server-with-password-reset/src/RedisStore.js
@@ -106,4 +106,30 @@ export default class RedisStore {
   async removeResetCode(name) {
     await this.client.del(`reset:${name}`);
   }
+
+  /**
+   * @param {string} id
+   */
+  async getSession(id) {
+    const { userIdentifier, sessionKey } = await this.client.hGetAll(
+      `session:${id}`
+    );
+    if (!userIdentifier || !sessionKey) throw new TypeError();
+    return { userIdentifier, sessionKey };
+  }
+
+  /**
+   * @param {string} id
+   * @param {SessionData} session
+   */
+  async setSession(id, session) {
+    await this.client.hSet(`session:${id}`, /** @type {any} */ (session));
+  }
+
+  /**
+   * @param {string} id
+   */
+  async clearSession(id) {
+    await this.client.del(`session:${id}`);
+  }
 }

--- a/examples/server-with-password-reset/src/server.js
+++ b/examples/server-with-password-reset/src/server.js
@@ -7,6 +7,7 @@ import InMemoryStore, {
   writeDatabaseFile,
 } from "./InMemoryStore.js";
 import RedisStore from "./RedisStore.js";
+import * as dotenv from "dotenv";
 
 /**
  * @type {Record<string, string>}
@@ -18,13 +19,22 @@ const enableRedis = process.argv.includes("--redis");
 
 const DEFAULT_REDIS_URL = "redis://127.0.0.1:6379";
 
+function getOpaqueServerSetup() {
+  const serverSetup = process.env.OPAQUE_SERVER_SETUP;
+  if (serverSetup == null) {
+    console.error(process.env);
+    throw new Error("OPAQUE_SERVER_SETUP env variable is not set");
+  }
+  return serverSetup;
+}
+
 /**
  * @param {string} filePath
  */
 async function initInMemoryStore(filePath) {
   await opaque.ready;
   if (!enableJsonFilePersistence) {
-    return InMemoryStore.empty(opaque.server.createSetup());
+    return InMemoryStore.empty();
   }
   try {
     const db = readDatabaseFile(filePath);
@@ -41,7 +51,7 @@ async function initInMemoryStore(filePath) {
         err
       );
     }
-    const db = InMemoryStore.empty(opaque.server.createSetup());
+    const db = InMemoryStore.empty();
     return db;
   }
 }
@@ -51,14 +61,8 @@ async function initInMemoryStore(filePath) {
  */
 let db;
 
-/**
- * @type {string}
- */
-let serverSetup;
-
 async function setUpInMemoryStore() {
   const memDb = await initInMemoryStore(dbFile);
-  serverSetup = memDb.serverSetup;
 
   if (enableJsonFilePersistence) {
     writeDatabaseFile(dbFile, memDb);
@@ -88,12 +92,6 @@ async function setUpRedisStore() {
       process.exit(1);
     });
     await redis.connect();
-    let _serverSetup = await redis.getServerSetup();
-    if (_serverSetup == null) {
-      _serverSetup = opaque.server.createSetup();
-      redis.setServerSetup(_serverSetup);
-    }
-    serverSetup = _serverSetup;
     db = redis;
     console.log("connected to redis at", redisUrl);
   } catch (err) {
@@ -140,7 +138,7 @@ app.post("/register/start", async (req, res) => {
   }
 
   const { registrationResponse } = opaque.server.createRegistrationResponse({
-    serverSetup,
+    serverSetup: getOpaqueServerSetup(),
     userIdentifier,
     registrationRequest,
   });
@@ -175,7 +173,7 @@ app.post("/login/start", async (req, res) => {
   }
 
   const { serverLoginState, loginResponse } = opaque.server.startLogin({
-    serverSetup,
+    serverSetup: getOpaqueServerSetup(),
     userIdentifier,
     registrationRecord,
     startLoginRequest,
@@ -279,7 +277,7 @@ app.post("/password/reset/confirm", async (req, res) => {
   }
 
   const { registrationResponse } = opaque.server.createRegistrationResponse({
-    serverSetup,
+    serverSetup: getOpaqueServerSetup(),
     userIdentifier,
     registrationRequest,
   });
@@ -289,6 +287,7 @@ app.post("/password/reset/confirm", async (req, res) => {
 });
 
 async function main() {
+  dotenv.config({ debug: true, path: "../../.env" });
   await setupDb();
   const port = 8089;
   app.listen(port, () => {

--- a/examples/server-with-password-reset/src/server.js
+++ b/examples/server-with-password-reset/src/server.js
@@ -11,10 +11,6 @@ import RedisStore from "./RedisStore.js";
 
 dotenv.config({ path: "../../.env" });
 
-/**
- * @type {Record<string, {userIdentifier: string; sessionKey: string}>}
- */
-const activeSessions = {};
 const dbFile = "./data.json";
 const enableJsonFilePersistence = !readEnvFlag("DISABLE_FS");
 const enableRedis = readEnvFlag("ENABLE_REDIS");
@@ -210,9 +206,7 @@ app.post("/login/finish", async (req, res) => {
   });
 
   const sessionId = generateSessionId();
-
-  activeSessions[sessionId] = { userIdentifier, sessionKey };
-
+  await db.setSession(sessionId, { userIdentifier, sessionKey });
   await db.removeLogin(userIdentifier);
 
   res.cookie("session", sessionId, { httpOnly: true });
@@ -220,23 +214,23 @@ app.post("/login/finish", async (req, res) => {
   res.end();
 });
 
-app.post("/logout", (req, res) => {
+app.post("/logout", async (req, res) => {
   const sessionId = req.cookies.session;
   if (!sessionId) return sendError(res, 401, "not authorized");
 
-  const session = activeSessions[sessionId];
+  const session = await db.getSession(sessionId);
   if (!session) return sendError(res, 401, "invalid session");
 
-  delete activeSessions[sessionId];
+  await db.clearSession(sessionId);
   res.clearCookie("session");
   res.end();
 });
 
-app.get("/private", (req, res) => {
+app.get("/private", async (req, res) => {
   const sessionId = req.cookies.session;
   if (!sessionId) return sendError(res, 401, "not authorized");
 
-  const session = activeSessions[sessionId];
+  const session = await db.getSession(sessionId);
   if (!session) return sendError(res, 401, "invalid session");
 
   res.send({

--- a/examples/server-with-password-reset/src/server.js
+++ b/examples/server-with-password-reset/src/server.js
@@ -1,18 +1,18 @@
 import * as opaque from "@serenity-kit/opaque";
-import cors from "cors";
+import cookieParser from "cookie-parser";
 import { randomInt } from "crypto";
+import * as dotenv from "dotenv";
 import express from "express";
 import InMemoryStore, {
   readDatabaseFile,
   writeDatabaseFile,
 } from "./InMemoryStore.js";
 import RedisStore from "./RedisStore.js";
-import * as dotenv from "dotenv";
 
 dotenv.config({ path: "../../.env" });
 
 /**
- * @type {Record<string, string>}
+ * @type {Record<string, {userIdentifier: string; sessionKey: string}>}
  */
 const activeSessions = {};
 const dbFile = "./data.json";
@@ -118,7 +118,11 @@ async function setupDb() {
 
 const app = express();
 app.use(express.json());
-app.use(cors());
+app.use(cookieParser());
+
+function generateSessionId() {
+  return randomInt(1e9, 1e10).toString();
+}
 
 /**
  * @param {import("express").Response} res
@@ -205,31 +209,39 @@ app.post("/login/finish", async (req, res) => {
     serverLoginState,
   });
 
-  activeSessions[sessionKey] = userIdentifier;
+  const sessionId = generateSessionId();
+
+  activeSessions[sessionId] = { userIdentifier, sessionKey };
 
   await db.removeLogin(userIdentifier);
 
+  res.cookie("session", sessionId, { httpOnly: true });
   res.writeHead(200);
   res.end();
 });
 
 app.post("/logout", (req, res) => {
-  const auth = req.get("authorization");
-  const userIdentifier = auth && activeSessions[auth];
-  if (!auth) return sendError(res, 401, "missing authorization header");
-  if (!userIdentifier) return sendError(res, 401, "no active session");
+  const sessionId = req.cookies.session;
+  if (!sessionId) return sendError(res, 401, "not authorized");
 
-  delete activeSessions[userIdentifier];
+  const session = activeSessions[sessionId];
+  if (!session) return sendError(res, 401, "invalid session");
+
+  delete activeSessions[sessionId];
+  res.clearCookie("session");
   res.end();
 });
 
 app.get("/private", (req, res) => {
-  const auth = req.get("authorization");
-  const user = auth && activeSessions[auth];
-  if (!auth) return sendError(res, 401, "missing authorization header");
-  if (!user) return sendError(res, 401, "no active session");
+  const sessionId = req.cookies.session;
+  if (!sessionId) return sendError(res, 401, "not authorized");
 
-  res.send({ message: `hello ${user} from opaque-authenticated world` });
+  const session = activeSessions[sessionId];
+  if (!session) return sendError(res, 401, "invalid session");
+
+  res.send({
+    message: `hello ${session.userIdentifier} from opaque-authenticated world`,
+  });
   res.end();
 });
 

--- a/examples/server-with-password-reset/src/server.js
+++ b/examples/server-with-password-reset/src/server.js
@@ -9,15 +9,31 @@ import InMemoryStore, {
 import RedisStore from "./RedisStore.js";
 import * as dotenv from "dotenv";
 
+dotenv.config({ path: "../../.env" });
+
 /**
  * @type {Record<string, string>}
  */
 const activeSessions = {};
 const dbFile = "./data.json";
-const enableJsonFilePersistence = !process.argv.includes("--no-fs");
-const enableRedis = process.argv.includes("--redis");
+const enableJsonFilePersistence = !readEnvFlag("DISABLE_FS");
+const enableRedis = readEnvFlag("ENABLE_REDIS");
 
 const DEFAULT_REDIS_URL = "redis://127.0.0.1:6379";
+const REDIS_URL = process.env.REDIS_URL || DEFAULT_REDIS_URL;
+
+/**
+ * @param {string} key
+ */
+function readEnvFlag(key) {
+  const value = process.env[key];
+  if (value == null) return false;
+  try {
+    return Boolean(JSON.parse(value));
+  } catch (err) {
+    return false;
+  }
+}
 
 function getOpaqueServerSetup() {
   const serverSetup = process.env.OPAQUE_SERVER_SETUP;
@@ -73,27 +89,16 @@ async function setUpInMemoryStore() {
   db = memDb;
 }
 
-function getRedisUrl() {
-  const optIndex = process.argv.indexOf("--redis");
-  if (optIndex == -1) return DEFAULT_REDIS_URL;
-  const valIndex = optIndex + 1;
-  if (valIndex < process.argv.length) {
-    return process.argv[valIndex];
-  }
-  return DEFAULT_REDIS_URL;
-}
-
 async function setUpRedisStore() {
   try {
-    const redisUrl = getRedisUrl();
-    const redis = new RedisStore(redisUrl);
+    const redis = new RedisStore(REDIS_URL);
     redis.onError((err) => {
       console.error("Redis Error:", err instanceof Error ? err.message : err);
       process.exit(1);
     });
     await redis.connect();
     db = redis;
-    console.log("connected to redis at", redisUrl);
+    console.log("connected to redis at", REDIS_URL);
   } catch (err) {
     console.error(
       "Redis Setup Error:",
@@ -287,7 +292,6 @@ app.post("/password/reset/confirm", async (req, res) => {
 });
 
 async function main() {
-  dotenv.config({ debug: true, path: "../../.env" });
   await setupDb();
   const port = 8089;
   app.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "node ./bin/build.js && pnpm gen:dotenv",
     "gen:dotenv": "node ./bin/generate-dotenv.js",
-    "example:fullstack-simple-nextjs:dev": "cd examples/fullstack-simple-nextjs && cross-env OPAQUE_SERVER_SETUP=Ki5T3U21n_UFhcGP5fR_mUstYEItKRsjEJ2UnvvrGasT3wvjdtbluS0BsiR_LtzqX8YLrCyWqQOJDf7cL0C8DRr9pGFBSx0X22ZujePyWpdq4VddBSPm0vIXepDJEBYJjRxmRNh09pLGxk_Y9bQuFWjYInqjcy_zOVsMHPHUkQw pnpm dev",
+    "example:fullstack-simple-nextjs:dev": "cd examples/fullstack-simple-nextjs && pnpm dev",
     "example:client-simple-webpack:dev": "cd examples/client-simple-webpack && pnpm dev",
     "example:client-with-password-reset:dev": "cd examples/client-with-password-reset && pnpm dev",
     "example:client-simple-vite:dev": "cd examples/client-simple-vite && pnpm dev",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typescript": "5.1.3"
   },
   "scripts": {
-    "build": "node ./bin/build.js",
+    "build": "node ./bin/build.js && pnpm gen:dotenv",
+    "gen:dotenv": "node ./bin/generate-dotenv.js",
     "example:fullstack-simple-nextjs:dev": "cd examples/fullstack-simple-nextjs && cross-env OPAQUE_SERVER_SETUP=Ki5T3U21n_UFhcGP5fR_mUstYEItKRsjEJ2UnvvrGasT3wvjdtbluS0BsiR_LtzqX8YLrCyWqQOJDf7cL0C8DRr9pGFBSx0X22ZujePyWpdq4VddBSPm0vIXepDJEBYJjRxmRNh09pLGxk_Y9bQuFWjYInqjcy_zOVsMHPHUkQw pnpm dev",
     "example:client-simple-webpack:dev": "cd examples/client-simple-webpack && pnpm dev",
     "example:client-with-password-reset:dev": "cd examples/client-with-password-reset && pnpm dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -3492,6 +3495,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: false
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
     dev: false
 
   /ee-first@1.1.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -59,7 +63,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^4.3.2
-        version: 4.3.8
+        version: 4.3.8(@types/node@20.2.5)
 
   examples/client-simple-webpack:
     dependencies:
@@ -130,7 +134,7 @@ importers:
         version: 13.4.4(eslint@8.42.0)(typescript@5.1.3)
       next:
         specifier: 13.4.4
-        version: 13.4.4(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.4(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
       postcss:
         specifier: 8.4.24
         version: 8.4.24
@@ -158,6 +162,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.18.2
+      redis:
+        specifier: ^4.6.7
+        version: 4.6.7
     devDependencies:
       '@types/cors':
         specifier: ^2.8.13
@@ -198,19 +205,16 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
 
   /@babel/code-frame@7.21.4:
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
-    dev: true
 
   /@babel/compat-data@7.21.4:
     resolution: {integrity: sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/core@7.21.4:
     resolution: {integrity: sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==}
@@ -233,7 +237,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/generator@7.21.4:
     resolution: {integrity: sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==}
@@ -243,7 +246,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
-    dev: true
 
   /@babel/helper-annotate-as-pure@7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -272,7 +274,6 @@ packages:
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
-    dev: true
 
   /@babel/helper-create-class-features-plugin@7.21.4(@babel/core@7.21.4):
     resolution: {integrity: sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==}
@@ -323,7 +324,6 @@ packages:
   /@babel/helper-environment-visitor@7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-explode-assignable-expression@7.18.6:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
@@ -338,14 +338,12 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/helper-member-expression-to-functions@7.21.0:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
@@ -359,7 +357,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/helper-module-transforms@7.21.2:
     resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
@@ -375,7 +372,6 @@ packages:
       '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-optimise-call-expression@7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -423,7 +419,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
@@ -437,22 +432,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-wrap-function@7.20.5:
     resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
@@ -475,7 +466,6 @@ packages:
       '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -484,7 +474,6 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: true
 
   /@babel/parser@7.21.4:
     resolution: {integrity: sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==}
@@ -492,7 +481,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.4):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -1385,7 +1373,6 @@ packages:
       '@babel/code-frame': 7.21.4
       '@babel/parser': 7.21.4
       '@babel/types': 7.21.4
-    dev: true
 
   /@babel/traverse@7.21.4:
     resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
@@ -1403,7 +1390,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types@7.21.4:
     resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
@@ -1412,7 +1398,6 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2078,6 +2063,55 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /@redis/bloom@1.2.0(@redis/client@1.5.8):
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.8
+    dev: false
+
+  /@redis/client@1.5.8:
+    resolution: {integrity: sha512-xzElwHIO6rBAqzPeVnCzgvrnBEcFL1P0w8P65VNLRkdVW8rOE58f52hdj0BDgmsdOm4f1EoXPZtH4Fh7M/qUpw==}
+    engines: {node: '>=14'}
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+    dev: false
+
+  /@redis/graph@1.1.0(@redis/client@1.5.8):
+    resolution: {integrity: sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.8
+    dev: false
+
+  /@redis/json@1.0.4(@redis/client@1.5.8):
+    resolution: {integrity: sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.8
+    dev: false
+
+  /@redis/search@1.1.3(@redis/client@1.5.8):
+    resolution: {integrity: sha512-4Dg1JjvCevdiCBTZqjhKkGoC5/BcB7k9j99kdMnaXFXg8x4eyOIVg9487CMv7/BUVkFLZCaIh8ead9mU15DNng==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.8
+    dev: false
+
+  /@redis/time-series@1.0.4(@redis/client@1.5.8):
+    resolution: {integrity: sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.8
+    dev: false
+
   /@rollup/plugin-wasm@6.1.3(rollup@3.23.0):
     resolution: {integrity: sha512-7ItTTeyauE6lwdDtQWceEHZ9+txbi4RRy0mYPFn9BW7rD7YdgBDu7HTHsLtHrRzJc313RM/1m6GKgV3np/aEaw==}
     engines: {node: '>=14.0.0'}
@@ -2593,8 +2627,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -2658,7 +2694,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
-    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -3047,7 +3082,6 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    dev: true
 
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3111,6 +3145,11 @@ packages:
       shallow-clone: 3.0.1
     dev: true
 
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -3124,7 +3163,6 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
-    dev: true
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3134,7 +3172,6 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -3199,7 +3236,6 @@ packages:
 
   /convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: true
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3616,7 +3652,6 @@ packages:
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: true
 
   /escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -4171,10 +4206,14 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
+  /generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+    dev: false
+
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -4263,7 +4302,6 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: true
 
   /globals@13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
@@ -4325,7 +4363,6 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5234,7 +5271,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -5262,7 +5298,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: true
 
   /jsx-ast-utils@3.3.3:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
@@ -5358,7 +5393,6 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
-    dev: true
 
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -5496,7 +5530,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next@13.4.4(react-dom@18.2.0)(react@18.2.0):
+  /next@13.4.4(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==}
     engines: {node: '>=16.8.0'}
     hasBin: true
@@ -5521,7 +5555,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.21.4)(react@18.2.0)
       zod: 3.21.4
     optionalDependencies:
       '@next/swc-darwin-arm64': 13.4.4
@@ -6056,6 +6090,17 @@ packages:
       resolve: 1.22.2
     dev: true
 
+  /redis@4.6.7:
+    resolution: {integrity: sha512-KrkuNJNpCwRm5vFJh0tteMxW8SaUzkm5fBH7eL5hd/D0fAkzvapxbfGPP/r+4JAXdQuX7nebsBkBqA2RHB7Usw==}
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.5.8)
+      '@redis/client': 1.5.8
+      '@redis/graph': 1.1.0(@redis/client@1.5.8)
+      '@redis/json': 1.0.4(@redis/client@1.5.8)
+      '@redis/search': 1.1.3(@redis/client@1.5.8)
+      '@redis/time-series': 1.0.4(@redis/client@1.5.8)
+    dev: false
+
   /regenerate-unicode-properties@10.1.0:
     resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
     engines: {node: '>=4'}
@@ -6249,7 +6294,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: true
 
@@ -6572,7 +6617,7 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /styled-jsx@5.1.1(react@18.2.0):
+  /styled-jsx@5.1.1(@babel/core@7.21.4)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -6585,6 +6630,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
+      '@babel/core': 7.21.4
       client-only: 0.0.1
       react: 18.2.0
     dev: false
@@ -6608,7 +6654,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: true
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -6748,7 +6793,6 @@ packages:
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
-    dev: true
 
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6914,7 +6958,7 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@4.3.8:
+  /vite@4.3.8(@types/node@20.2.5):
     resolution: {integrity: sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -6939,6 +6983,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.2.5
       esbuild: 0.17.19
       postcss: 8.4.24
       rollup: 3.23.0
@@ -7221,7 +7266,6 @@ packages:
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-    dev: true
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.18.2
+      redis:
+        specifier: ^4.6.7
+        version: 4.6.7
     devDependencies:
       '@types/cors':
         specifier: ^2.8.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.24)
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       eslint:
         specifier: 8.42.0
         version: 8.42.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      redis:
+        specifier: ^4.6.7
+        version: 4.6.7
       tailwindcss:
         specifier: 3.3.2
         version: 3.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,9 +162,9 @@ importers:
       '@serenity-kit/opaque':
         specifier: workspace:*
         version: link:../../build/ristretto
-      cors:
-        specifier: ^2.8.5
-        version: 2.8.5
+      cookie-parser:
+        specifier: ^1.4.6
+        version: 1.4.6
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -175,9 +175,9 @@ importers:
         specifier: ^4.6.7
         version: 4.6.7
     devDependencies:
-      '@types/cors':
-        specifier: ^2.8.13
-        version: 2.8.13
+      '@types/cookie-parser':
+        specifier: ^1.4.3
+        version: 1.4.3
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.17
@@ -187,9 +187,9 @@ importers:
       '@serenity-kit/opaque':
         specifier: workspace:*
         version: link:../../build/ristretto
-      cors:
-        specifier: ^2.8.5
-        version: 2.8.5
+      cookie-parser:
+        specifier: ^1.4.6
+        version: 1.4.6
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -200,9 +200,9 @@ importers:
         specifier: ^4.6.7
         version: 4.6.7
     devDependencies:
-      '@types/cors':
-        specifier: ^2.8.13
-        version: 2.8.13
+      '@types/cookie-parser':
+        specifier: ^1.4.3
+        version: 1.4.3
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.17
@@ -2220,10 +2220,10 @@ packages:
       '@types/node': 20.2.5
     dev: true
 
-  /@types/cors@2.8.13:
-    resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
+  /@types/cookie-parser@1.4.3:
+    resolution: {integrity: sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/express': 4.17.17
     dev: true
 
   /@types/eslint-scope@3.7.4:
@@ -3256,8 +3256,21 @@ packages:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
 
+  /cookie-parser@1.4.6:
+    resolution: {integrity: sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      cookie: 0.4.1
+      cookie-signature: 1.0.6
+    dev: false
+
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  /cookie@0.4.1:
+    resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
@@ -3287,14 +3300,6 @@ packages:
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
-
-  /cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
-    dev: false
 
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}


### PR DESCRIPTION
Additional changes:
- generate `.env` file and use env variables to configure opaque server setup, redis etc.
- refactor session handling to go through store interface (to persist in redis when using redis)
- set session cookie with random session ID instead of using opaque sessionKey in auth header in `/private` endpoint example
- remove cors and configure proxy instead (to avoid additional cors session handling complexity)
